### PR TITLE
Kenson/remove ts node

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,21 +23,23 @@ _When you first start learning TypeScript, this allows you to simply write your 
 
 #### Manually
 
-For running any TS file, just run `npx ts-node path/to/file.ts` to run the file.
+For running any TS file, just run `npm run file path/to/file.ts` to run the file. For example, if you wanted to run the `index.ts` file from the project root, you would run `npm run file src/index.ts`.
 
 ## About This Repo
 
-This repo was made to give newcomers to TypeScript a simple environment to learn what it's all about.
+This repo was made to give newcomers to TypeScript a simple environment to learn what it's all about. I will make some assumptions about your knowledge of JavaScript, but I will try to explain things as best as I can.
 
 ## Usage
 
-Some helpful npm scripts are available:
+Some helpful npm scripts are available in the `package.json` file:
 
 `npm start`
 
+`npm run build`
+
 `npm run dev`
 
-`npm run build`
+`npm run file`
 
 ## Guided TypeScript Setup
 
@@ -54,27 +56,34 @@ mkdir my-project
 cd my-project
 ```
 
-Once you're sitting in your project's directory, we need to initialize this project as a Node project:
+Once you're sitting in your project's directory, we need to initialize this project as a Node project.
+_This assumes you have Node installed on your computer. If you need to install Node, get the latest version for your OS from [the official Node.js site](https://nodejs.org/en)._
+Once you have Node installed, run the following command to initialize this directory as a Node project:
 
-_This assumes you have Node installed_
-
-```
+```sh
 npm init -y
 ```
 
-This will give us a `package.json` and the start of our project.
-_Now is a good time to create your `.gitignore` and add `node_modules` to it!_
+This will give us a `package.json` and the start of our project!
+
+If you want to upload your project to github, _now is a good time to create your `.gitignore` and add `node_modules` to it!_ This command will create a `.gitignore` file and add `node_modules` to it:
+
+```sh
+echo "node_modules" > .gitignore
+```
+
+We haven't initialized this directory as a `git` repo, but this will save us from messing up later, if we decide to add git to our project.
 
 ### Installing TypeScript
 
 Let's get TypeScript installed.
-TS is something that only runs in our development environment, so we can save it as a dev dependency:
+TS is something that only runs in our development environment, so we can save it as a dev dependency. Notice the `--save-dev` flag:
 
 ```sh
 npm install --save-dev typescript
 ```
 
-This downloads TypeScript, but we also need to configure it so it knows what rules to follow.
+This downloads TypeScript and adds it to our `node_modules`, but we also need to configure it so it knows what rules to follow.
 We do this by calling the init function in the TypeScript compiler (TSC):
 
 ```sh
@@ -85,12 +94,13 @@ npx tsc --init --rootDir src --outDir build \
 
 _`npx` differs from `npm`: use `npm` to **install** a package and use `npx` to **execute** (run) a program._
 
-Running that command results in a `tsconfig.json` being created with some sensible defaults.
+Running the above command results in a `tsconfig.json` being created with some sensible defaults.
 If you wanted to, you could look into this file to read up on the settings turned on in your project.
 
 One thing to note here is the opinionated project structure.
 The TypeScript config file is setup to look for files in a directory called `src` and it builds the final project into a directory called `build`.
 You don't have to do it this way, but I would leave it as is if you're new.
+I will explain why we are setting the project up this way in a later step.
 Let's go ahead and create that `src` directory:
 
 ```sh
@@ -101,7 +111,7 @@ All of your `.ts` and `.js` files should go in this directory.
 
 ### Adding Types
 
-Thanks to a [really awesome package](https://github.com/DefinitelyTyped/DefinitelyTyped "DefinitelyTyped Project Repo"), we can simply download premade type libraries for most popular packages.
+Thanks to [this awesome npm package](https://github.com/DefinitelyTyped/DefinitelyTyped "DefinitelyTyped Project Repo"), we can simply download premade type libraries for most popular packages.
 Whenever you want to get the types for a package, simply use this format during the install: `@types/name-of-package`.
 We know that we're going to be using Node, so we might as well grab the types for it:
 
@@ -109,7 +119,7 @@ We know that we're going to be using Node, so we might as well grab the types fo
 npm install --save-dev @types/node
 ```
 
-_Notice that we saved our types as a dev dependency using `--save-dev`._
+_Notice that we saved our types as a dev dependency using `--save-dev`. Types are for the Development Environment._
 
 ### Testing the setup
 
@@ -142,17 +152,67 @@ You can now create your project inside of the `src` directory and compile to Jav
 
 ### Setting Up the Dev Environment
 
-What we have right now is really cool, but it does get very tiring having to run `npx tsc` everytime I want to run my code.
+What we have right now is really cool, but it does get very tiring having to run `npx tsc` and manually run my JavaScript file everytime I want to see the changes.
 We can add some helpful tools to help us out:
 
-- ts-node - Runs TypeScript files the way that Node runs JavaScript files.
-- nodemon - monitors the files in you project and restarts Node each time a file is saved.
+- `ts-node` - Runs TypeScript files the way that Node runs JavaScript files.
+- `nodemon` - Monitors the files in you project and restarts Node each time a file is saved.
 
 Having these will allow us to see our code changes in real time.
-These are dev dependencies like all the rest we've talked about above, so install like this:
+I'll go over each of these in detail.
+
+#### ts-node
+
+I'll start with `ts-node` and show how to run a TypeScript file with it.
+Let's start by installing it as a dev dependency:
 
 ```sh
-npm install --save-dev ts-node nodemon
+npm install --save-dev ts-node
+```
+
+Once again, this is a dev dependency because it's only used in the development environment.
+To run a file with `ts-node`, we use the following command:
+
+```sh
+npx ts-node path/to/file.ts
+```
+
+So, if we wanted to run the `index.ts` file from the project root, we would run `npx ts-node src/index.ts`.
+As mentioned above, `npx` is how we run a program that we installed with `npm`.
+Running the above command will interpet out TypeScript file and run it with Node.
+This is great for running a file one time and seeing the output.
+
+Knowing how to run files manually is great, but we want to run our environment to handle running our files for us.
+Let's do that by setting up a script for `npm` to run.
+
+Open up the `package.json` file and locate the section called `scripts`.
+By default, there is a `test` script in there, which we won't be using.
+We can delete that and add our own script called `file`:
+
+```json
+"file": "npx ts-node src/index.ts"
+```
+
+Any key -> value pair you add here will be available to run with `npm run`.
+So, if you wanted to run the `file` script, you would run `npm run file`.
+Let's run our `index.ts`:
+
+```sh
+npm run file scr/index.ts
+```
+
+While not terribly useful to us right now, knowing `npm` scripts will be very useful in the next section.
+
+#### nodemon
+
+Instead of running our files manually each time we want to see the output, it would be awesome to start setting up our environment to do that for us. We can rerun our files each time we save them if we setup a nifty package called `nodemon`.
+
+Think of `nodemon` as a "Node Monitor" that will allow us to re-run our code each time we save a file. I'll show you how to set it up and then explain what's going on.
+
+First, install `nodemon` as a dev dependency:
+
+```sh
+npm install --save-dev nodemon
 ```
 
 Next, create a file in the root of your project called `nodemon.json` and add the following:
@@ -162,18 +222,39 @@ Next, create a file in the root of your project called `nodemon.json` and add th
   "watch": ["src"],
   "ext": ".ts,.js",
   "ignore": [],
-  "exec": "npx ts-node ./src/index.ts"
+  "exec": "tsc && node ./build/index.js"
 }
 ```
 
-The above configuration file is rather simple:
+The above configuration file is rather simple, and we can go over each bit:
 
 - `watch` tells nodemon which directories to look in.
 - `ext` specifies what file extensions to monitor.
-- `ignore` specifies files not to look at.
+- `ignore` specifies files skip over and not watch.
 - `exec` is the command that will be ran when a file is changed.
 
-Now we can make a convenience script for running our dev environment.
+What you might notice is that we aren't running `ts-node` in the `exec` command.
+In fact, we aren't specifying any `.ts` files at all!
+What gives?
+Well, it is a common pattern to compile your TypeScript into JavaScript first, and then run the plain JavaScript.
+This is the most likely setup you will see when working on a project with TypeScript.
+
+Let's break down exaclty what is happening in the `exec` command:
+
+- `tsc` - This is the TypeScript compiler. It will compile all of our TypeScript files into JavaScript. The result will be a `build` directory with all of our JavaScript files in it.
+- `node ./build/index.js` - This is the command that will be ran after the TypeScript compiler finishes. It will run the `index.js` file from inside the `build` directory.
+
+Remember we ran `npx tsc` earlier and it created a `build` directory with an `index.js` file inside?
+This is why we set up our project structure the way we did.
+In most projects, you will see some type of `src` directory with all of the TypeScript files and a `build` directory with all of the JavaScript files.
+Though, the specifics of the project may differ, such as having a `dist` directory instead of a `build` directory, or having a `app` directory instead of a `src` directory.
+
+What's important to recognise is that TypeScript uses a _transpiler_, and doesn't run the code directly.
+Your awesome TypeScript code is converted into JavaScript, and then the JavaScript is ran.
+This is why TypeScript is considered to provide build-time type checking, and not run-time type checking.
+There are no types when _running_ the code, only when _building_ the code.
+
+With all of that being said, let's start making our dev environment.
 Open up the `package.json` and locate the section called `scripts`.
 Inside of scripts add the following:
 
@@ -185,4 +266,67 @@ Now you can just run `npm run dev` one time and it will start monitoring your pr
 Each time you save the file, it will run the TypeScript compiler and then run `index.js` from inside your `build` directory.
 Nice!
 
-**_When you want to stop the dev server, press CTRL + c on your keyboard_**
+When you want to stop the dev server, press `CTRL + c` on your keyboard. This isn't specific to `nodemon`, but is a common way to stop a process in the terminal.
+
+### Building For Production
+
+I hope I've made it abundantly clear that TypeScript is not ran in the production environment.
+It is only used in the development environment to help us write better "type safe" code.
+When we are ready to deploy our code, we need to build it into JavaScript.
+
+While not important for what we're doing in this project, I want to simulate what "building for production" looks like.
+
+Let's start off by adding a couple more scripts to our `package.json`:
+
+```json
+"build": "tsc",
+"start": "node ./build/index.js"
+```
+
+The `build` script will run the TypeScript compiler and build our project into JavaScript.
+The `start` script will run the `index.js` file from inside the `build` directory.
+
+Nothing about this is helping our project, but most frameworks will optimize the build during this step.
+This could mean "minifying" the code (removing all whitespace and comments), or "tree shaking" (removing unused code), or "bundling" (combining all of the code into a single file).
+What results is a smaller and more optimized file that is ready to be deployed.
+
+We can turn on some of the optimizations ourselves by adding another flag to the `tsconfig.json` file.
+Open up the `tsconfig.json` find the line that says:
+
+```json
+// "removeComments": true, /* Disable emitting comments. */
+```
+
+and change it to:
+
+```json
+"removeComments": true, /* Disable emitting comments. */
+```
+
+Go back to your `index.ts` file and add a comment:
+
+```TypeScript
+// This comment is only for the source code
+const myMessage: String = "Hello TypeScript!"
+
+console.log(myMessage)
+```
+
+Now run `npm run build` and open up the `index.js` file from inside the `build` directory.
+
+Notice that the comment is gone:
+
+```JavaScript
+"use strict";
+const myMessage = "Hello TypeScript!";
+console.log(myMessage);
+```
+
+This is a very simple example of what happens when a framework builds your code for production.
+It's not useful here because it would be better to keep the comments in while you're learning TypeScript.
+I suggest changing the `removeComments` flag back to `false` in the `tsconfig.json` file for now.
+
+### Conclusion
+
+I hope this repo has helped you get started with TypeScript.
+It may seem overwhelming at first, but it's really not that bad. I suggest you start by writing some simple JavaScript in `.ts` files, which gives you many benefits from "infered types" and code completion. Start adding types to your variables, then to your functions, and eventually you will get the full benefits of TypeScript.

--- a/nodemon.json
+++ b/nodemon.json
@@ -2,5 +2,5 @@
   "watch": ["src"],
   "ext": ".ts,.js",
   "ignore": [],
-  "exec": "npx ts-node ./src/index.ts"
+  "exec": "tsc && node ./build/index.js"
 }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,13 @@
 {
   "name": "simple-typescript-template",
   "version": "1.0.0",
-  "type": "module",
   "description": "A no bells and whistles template to setup a TypeScript project. Perfect for beginners just learning TS.",
   "main": "index.js",
   "scripts": {
-    "dev": "npx nodemon"
+    "start": "node build/index.js",
+    "build": "tsc",
+    "file": "ts-node",
+    "dev": "nodemon"
   },
   "keywords": [],
   "author": "Kenson Johnson",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,10 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "lib": ["es6"],                                      /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "lib": [
+      "es6"
+    ] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
@@ -25,8 +27,8 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
-    "rootDir": "src",                                    /* Specify the root folder within your source files. */
+    "module": "commonjs" /* Specify what module code is generated. */,
+    "rootDir": "src" /* Specify the root folder within your source files. */,
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
@@ -39,12 +41,12 @@
     // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
     // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
     // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
-    "resolveJsonModule": true,                           /* Enable importing .json files. */
+    "resolveJsonModule": true /* Enable importing .json files. */,
     // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
     // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
 
     /* JavaScript Support */
-    "allowJs": true,                                     /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    "allowJs": true /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */,
     // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
 
@@ -55,7 +57,7 @@
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "build",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "build" /* Specify an output folder for all emitted files. */,
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
@@ -77,13 +79,13 @@
     // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
 
     /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
-    "noImplicitAny": true,                               /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    "strict": true /* Enable all strict type-checking options. */,
+    "noImplicitAny": true /* Enable error reporting for expressions and declarations with an implied 'any' type. */,
     // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
     // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
@@ -104,6 +106,6 @@
 
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
   }
 }


### PR DESCRIPTION
# Adds new npm scripts

The `package.json` now has these scripts added:

- `file` for running a `.ts` file with `ts-node`
- `build` for compiling the TypeScript files to the build directory
- `start` to run the `index.js` from the build directory

## Other changes

Changed the `nodemon` command to run the TypeScript compiler and then run the resulting JavaScript with Node.